### PR TITLE
org.adi.Scopy.json: Do not use native file dialogs in flatpaks.

### DIFF
--- a/org.adi.Scopy.json
+++ b/org.adi.Scopy.json
@@ -443,7 +443,7 @@
 			"name": "scopy",
 			"builddir": true,
 			"buildsystem": "cmake",
-			"config-opts": [ "-DCMAKE_INSTALL_PREFIX:PATH=/app", "-DCMAKE_PREFIX_PATH=/app/lib/pkgconfig;/app/lib/cmake", "-DWITH_DOC=OFF", "-DCMAKE_BUILD_TYPE=Release", "-DBREAKPAD_HANDLER=OFF" ],
+			"config-opts": [ "-DCMAKE_INSTALL_PREFIX:PATH=/app", "-DCMAKE_PREFIX_PATH=/app/lib/pkgconfig;/app/lib/cmake", "-DWITH_DOC=OFF", "-DCMAKE_BUILD_TYPE=Release", "-DBREAKPAD_HANDLER=OFF", "-DWITH_NATIVEDIALOGS=OFF" ],
 			"sources": [
 				{
 					"type": "git",


### PR DESCRIPTION
These dialogs don't save files properly, depending on the system theme,
flatpak theme, and probably some Runtime/Sdk version. If we use the
Qt dialogs, everything seems to work fine.

Signed-off-by: AlexandraTrifan <Alexandra.Trifan@analog.com>