### PR TITLE
Fix boost and sigrokdecode

### DIFF
--- a/org.adi.Scopy.json
+++ b/org.adi.Scopy.json
@@ -81,8 +81,8 @@
 			"sources": [
 				{
 					"type": "archive",
-					"url": "http://dl.bintray.com/boostorg/release/1.65.0/source/boost_1_65_0.tar.gz",
-					"sha256": "8a142d33ab4b4ed0de3abea3280ae3b2ce91c48c09478518c73e5dd2ba8f20aa"
+					"url": "https://boostorg.jfrog.io/artifactory/main/release/1.65.1/source/boost_1_65_1.tar.gz",
+					"sha256": "a13de2c8fbad635e6ba9c8f8714a0e6b4264b60a29b964b940a22554705b6b60"
 				},
 				{
 					"type": "script",

--- a/org.adi.Scopy.json
+++ b/org.adi.Scopy.json
@@ -447,11 +447,13 @@
 		},
 		{
 			"name": "sigrokdecode",
+			"builddir": false,
+			"buildsystem": "autotools",
+			"config-opts": [ "--prefix=/app" ],
 			"sources": [
 				{
-					"type": "archive",
-					"url": "https://swdownloads.analog.com/cse/scopydeps/libsigrokdecode-0.5.3.tar.gz",
-					"sha256": "c50814aa6743cd8c4e88c84a0cdd8889d883c3be122289be90c63d7d67883fc0"
+					"type": "git",
+					"url": "https://github.com/sigrokproject/libsigrokdecode"
 				}
 			]
 		},


### PR DESCRIPTION
- Use libsigrokdecode latest version.
- Change boost download location.

- [x] Test flatpak