### PR TITLE
Makefile: Add an extra check for the preprocess step in the build stage.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ SRC := org.adi.Scopy.json
 ifndef ARCH
 	ARCH := x86_64
 endif
+ifndef EN_PREPROCESS
+	EN_PREPROCESS := true
+endif
 
 .PHONY: all clean
 
@@ -19,13 +22,15 @@ build: preprocess
 	flatpak-builder --verbose --arch=$(ARCH) $@ $(SRC)
 
 preprocess: clean
-	if [ $(ARCH) = x86_64 ]; then \
-  		echo "-- Preprocessing org.adi.Scopy.json for ARCH = X86_64"; \
-  		gcc -E -P -D__X86__ org.adi.Scopy.json.c -o org.adi.Scopy.json; \
-  	elif [ $(ARCH) = arm ]; then \
-  	  	echo "-- Preprocessing org.adi.Scopy.json for ARCH = arm"; \
-  	  	gcc -E -P -D__ARM__ org.adi.Scopy.json.c -o org.adi.Scopy.json; \
-  	fi
+	if [ $(EN_PREPROCESS) = true ]; then \
+		if [ $(ARCH) = x86_64 ]; then \
+			echo "-- Preprocessing org.adi.Scopy.json for ARCH = X86_64"; \
+			gcc -E -P -D__X86__ org.adi.Scopy.json.c -o org.adi.Scopy.json; \
+		elif [ $(ARCH) = arm ]; then \
+			echo "-- Preprocessing org.adi.Scopy.json for ARCH = arm"; \
+			gcc -E -P -D__ARM__ org.adi.Scopy.json.c -o org.adi.Scopy.json; \
+		fi \
+	fi
 
 clean:
 	rm -rf $(TARGET) build repo


### PR DESCRIPTION
We need to be able to run the "preprocess" and the "build" step separately,
in order to correctly modify the org.adi.Scopy.json file if needed.
(to change the build branch for Scopy, for example).

Signed-off-by: AlexandraTrifan <Alexandra.Trifan@analog.com>