### PR TITLE
org.adi.Scopy.json: Lock libxml2 to an older version that works.

### DIFF
--- a/org.adi.Scopy.json.c
+++ b/org.adi.Scopy.json.c
@@ -196,7 +196,7 @@
 				{
 					"type": "git",
 					"url": "https://github.com/GNOME/libxml2",
-					"branch": "master"
+					"branch": "3c4e4bb7264afeab0704df287343d4c77ca8f8a1"
 				}
 			]
 		},


### PR DESCRIPTION
The latest version requires an updated version of autotools, which are not
updated in our build environment.

Signed-off-by: AlexandraTrifan <Alexandra.Trifan@analog.com>